### PR TITLE
Fix failing build on aarch64-linux-android

### DIFF
--- a/src/nameinfo.rs
+++ b/src/nameinfo.rs
@@ -46,9 +46,9 @@ pub fn getnameinfo(sock: &SocketAddr, flags: i32) -> Result<(String, String), Lo
       c_getnameinfo(
         c_sock, c_sock_len,
         c_host.as_mut_ptr(),
-        c_host.len() as u32,
+        c_host.len() as _,
         c_service.as_mut_ptr(),
-        c_service.len() as u32,
+        c_service.len() as _,
         flags
       )
     )?;


### PR DESCRIPTION
The types of arguments `hostlen` and `sevlen` on the libc function getnameinfo
differs between android anlinux. On linux they are `::socklen_t` which is
defined as a u32. Onandroid they are `::size_t` which is a usize. The
explicit cast to an u32 here make the build fail on android 64 bits.
Using `as _` instead of `as u32` makes the compiler choose the right
type for us at compile time