### PR TITLE
pass NI_NUMERICSERV to getnameinfo in lookup_addr

### DIFF
--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -3,10 +3,10 @@ use std::net::IpAddr;
 use std::str;
 
 #[cfg(unix)]
-use libc::SOCK_STREAM;
+use libc::{NI_NUMERICSERV, SOCK_STREAM};
 
 #[cfg(windows)]
-use winapi::shared::ws2def::SOCK_STREAM;
+use winapi::shared::ws2def::{NI_NUMERICSERV, SOCK_STREAM};
 
 use addrinfo::{getaddrinfo, AddrInfoHints};
 use nameinfo::getnameinfo;
@@ -49,7 +49,7 @@ pub fn lookup_host(host: &str) -> io::Result<Vec<IpAddr>> {
 /// Returns the hostname as a String, or an `io::Error` on failure.
 pub fn lookup_addr(addr: &IpAddr) -> io::Result<String> {
   let sock = (*addr, 0).into();
-  match getnameinfo(&sock, 0) {
+  match getnameinfo(&sock, NI_NUMERICSERV) {
     Ok((name, _)) => Ok(name),
     #[cfg(unix)]
     Err(e) => {


### PR DESCRIPTION
`lookup_addr` only returns the hostname, so there is no reason for us to
have `libnss` and friends look up the service name.

Currently, tight loops of `lookup_addr` result in a significant amount
of CPU time being spent in `libnss_files.so` to parse service names, as
`/etc/services` is generally tens of thousands of lines unlike `/etc/hosts`.

As an example, here is a redacted perf report before and after this commit:
https://gist.github.com/rahulg/e9440f65308dd2a9bdb8cfd815b95d0f