### PR TITLE
Skip call to res_init for MacOS and IOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ include = [
 [dependencies]
 socket2 = "^0.3"
 clippy = {version = "^0", optional = true}
+cfg-if = "^0.1"
 
 [target."cfg(windows)".dependencies.winapi]
 version = "^0.3"


### PR DESCRIPTION
res_init creates a redundant dependency to libresolv.tbd