### PR TITLE
Add cfg()s for redox

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -19,8 +19,10 @@ pub enum SockType {
   /// Connectionless, unreliable datagrams of fixed max length.
   DGram,
   /// Raw protocol interface.
+  #[cfg(not(target_os = "redox"))]
   Raw,
   /// Reliably-delivered messages.
+  #[cfg(not(target_os = "redox"))]
   RDM,
 }
 
@@ -29,7 +31,9 @@ impl From<SockType> for c_int {
     match sock {
       SockType::Stream => c::SOCK_STREAM,
       SockType::DGram => c::SOCK_DGRAM,
+      #[cfg(not(target_os = "redox"))]
       SockType::Raw => c::SOCK_RAW,
+      #[cfg(not(target_os = "redox"))]
       SockType::RDM => c::SOCK_RDM,
     }
   }


### PR DESCRIPTION
All the constants/function defs required for redox are currently on `libc` master, so once that merges/if you use a `patch` in Cargo.toml this compiles for redox.
