### PR TITLE
Fix compiling on wasm32-unknown-emscripten

### DIFF
--- a/src/err.rs
+++ b/src/err.rs
@@ -112,7 +112,7 @@ impl LookupErrorKind {
       c::EAI_MEMORY => LookupErrorKind::Memory,
       c::EAI_NONAME => LookupErrorKind::NoName,
       // FreeBSD has no EAI_NODATA, so don't match it on that platform.
-      #[cfg(not(target_os="freebsd"))]
+      #[cfg(not(any(target_os="freebsd", target_os="emscripten")))]
       c::EAI_NODATA => LookupErrorKind::NoData,
       c::EAI_SERVICE => LookupErrorKind::Service,
       c::EAI_SOCKTYPE => LookupErrorKind::Socktype,


### PR DESCRIPTION
It seems that freebsd isn't the only `os` where `EAI_NODATA` doesn't exist. Trivial fix.