### PR TITLE
Move from winapi to windows-sys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,9 @@ Cargo.lock
 
 # Project Vim Configuration
 .vimdir
+
+# Jetbrains Clion Configuration
+/.idea
+
+# main.rs
+/src/main.rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,20 @@ include = [
 ]
 
 [dependencies]
-socket2 = "^0.4"
+socket2 = {git = "https://github.com/rust-lang/socket2.git"}
 clippy = {version = "^0", optional = true}
 cfg-if = "^1.0"
 
-[target."cfg(windows)".dependencies.winapi]
-version = "^0.3"
-default-features = false
-features = ["windef", "ws2def", "ws2tcpip"]
+
+# [target."cfg(windows)".dependencies.winapi]
+# version = "^0.3"
+# default-features = false
+# features = ["windef", "ws2def", "ws2tcpip"]
+
+
+[target."cfg(windows)".dependencies.windows-sys]
+version = "0.36.1"
+features = ["Win32_Networking_WinSock", "Win32_Foundation"]
 
 [target."cfg(unix)".dependencies]
 libc = "^0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "dns-lookup"
 version = "1.0.8"
+edition = "2018"
 authors = ["Josh Driver <keeperofdakeys@gmail.com>"]
 description = "A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants."
 documentation = "https://docs.rs/dns-lookup"
@@ -16,16 +17,8 @@ include = [
 ]
 
 [dependencies]
-socket2 = {git = "https://github.com/rust-lang/socket2.git"}
-clippy = {version = "^0", optional = true}
+socket2 = { git = "https://github.com/rust-lang/socket2", branch="v0.4.x" }
 cfg-if = "^1.0"
-
-
-# [target."cfg(windows)".dependencies.winapi]
-# version = "^0.3"
-# default-features = false
-# features = ["windef", "ws2def", "ws2tcpip"]
-
 
 [target."cfg(windows)".dependencies.windows-sys]
 version = "0.36.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ include = [
 ]
 
 [dependencies]
-socket2 = { git = "https://github.com/rust-lang/socket2", branch="v0.4.x" }
+socket2 = { git = "https://github.com/rust-lang/socket2", branch="master" }
 cfg-if = "^1.0"
 
 [target."cfg(windows)".dependencies.windows-sys]
-version = "0.36.1"
+version = "0.36"
 features = ["Win32_Networking_WinSock", "Win32_Foundation"]
 
 [target."cfg(unix)".dependencies]

--- a/src/addrinfo.rs
+++ b/src/addrinfo.rs
@@ -4,6 +4,7 @@ use std::io;
 use std::mem;
 use std::net::SocketAddr;
 use std::ptr;
+use windows_sys;
 
 #[cfg(unix)]
 use libc::{addrinfo as c_addrinfo, freeaddrinfo as c_freeaddrinfo, getaddrinfo as c_getaddrinfo};
@@ -23,7 +24,7 @@ use windows_sys::Win32::Networking::WinSock::{
 use winapi::um::ws2tcpip::{freeaddrinfo as c_freeaddrinfo, getaddrinfo as c_getaddrinfo};
 */
 
-use err::LookupError;
+use crate::err::LookupError;
 
 /// A struct used as the hints argument to getaddrinfo.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -56,9 +57,9 @@ impl AddrInfoHints {
     #[allow(dead_code)]
     fn new(
         flags: Option<i32>,
-        address: Option<::AddrFamily>,
-        socktype: Option<::SockType>,
-        protocol: Option<::Protocol>,
+        address: Option<crate::AddrFamily>,
+        socktype: Option<crate::SockType>,
+        protocol: Option<crate::Protocol>,
     ) -> AddrInfoHints {
         AddrInfoHints {
             flags: flags.unwrap_or(0),
@@ -239,7 +240,7 @@ pub fn getaddrinfo(
 
     // Prime windows.
     #[cfg(windows)]
-    ::win::init_winsock();
+    crate::win::init_winsock();
 
     #[cfg(windows)]
     unsafe {
@@ -264,7 +265,7 @@ pub fn getaddrinfo(
 
 #[test]
 fn test_addrinfohints() {
-    use {AddrFamily, SockType};
+    use crate::{AddrFamily, SockType};
 
     assert_eq!(
         AddrInfoHints {

--- a/src/addrinfo.rs
+++ b/src/addrinfo.rs
@@ -131,7 +131,7 @@ impl AddrInfo {
         }
 
         let addrinfo = *a;
-        let ((), sockaddr) = SockAddr::init(|storage, len| {
+        let ((), sockaddr) = SockAddr::try_init(|storage, len| {
             *len = addrinfo.ai_addrlen as _;
             std::ptr::copy_nonoverlapping(
                 addrinfo.ai_addr as *const u8,

--- a/src/addrinfo.rs
+++ b/src/addrinfo.rs
@@ -6,141 +6,157 @@ use std::net::SocketAddr;
 use std::ptr;
 
 #[cfg(unix)]
-use libc::{getaddrinfo as c_getaddrinfo, freeaddrinfo as c_freeaddrinfo, addrinfo as c_addrinfo};
+use libc::{addrinfo as c_addrinfo, freeaddrinfo as c_freeaddrinfo, getaddrinfo as c_getaddrinfo};
+
+/*
+#[cfg(windows)]
+use winapi::shared::ws2def::ADDRINFOA as c_addrinfo;
+*/
 
 #[cfg(windows)]
-use winapi::shared::ws2def::{ADDRINFOA as c_addrinfo};
+use windows_sys::Win32::Networking::WinSock::{
+    freeaddrinfo as c_freeaddrinfo, getaddrinfo as c_getaddrinfo, ADDRINFOA as c_addrinfo,
+};
+
+/*
 #[cfg(windows)]
-use winapi::um::ws2tcpip::{getaddrinfo as c_getaddrinfo, freeaddrinfo as c_freeaddrinfo};
+use winapi::um::ws2tcpip::{freeaddrinfo as c_freeaddrinfo, getaddrinfo as c_getaddrinfo};
+*/
 
 use err::LookupError;
 
 /// A struct used as the hints argument to getaddrinfo.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct AddrInfoHints {
-  /// Optional bitmask arguments. Bitwise OR bitflags to change the
-  /// behaviour of getaddrinfo. 0 for none. `ai_flags` in libc.
-  ///
-  /// Values are defined by the libc on your system.
-  pub flags: i32,
-  /// Address family for this socket. 0 for none. `ai_family` in libc.
-  ///
-  /// Values are defined by the libc on your system.
-  pub address: i32,
-  /// Type of this socket. 0 for none. `ai_socktype` in libc.
-  ///
-  /// Values are defined by the libc on your system.
-  pub socktype: i32,
-  /// Protcol for this socket. 0 for none. `ai_protocol` in libc.
-  ///
-  /// Values are defined by the libc on your system.
-  pub protocol: i32,
+    /// Optional bitmask arguments. Bitwise OR bitflags to change the
+    /// behaviour of getaddrinfo. 0 for none. `ai_flags` in libc.
+    ///
+    /// Values are defined by the libc on your system.
+    pub flags: i32,
+    /// Address family for this socket. 0 for none. `ai_family` in libc.
+    ///
+    /// Values are defined by the libc on your system.
+    pub address: i32,
+    /// Type of this socket. 0 for none. `ai_socktype` in libc.
+    ///
+    /// Values are defined by the libc on your system.
+    pub socktype: i32,
+    /// Protcol for this socket. 0 for none. `ai_protocol` in libc.
+    ///
+    /// Values are defined by the libc on your system.
+    pub protocol: i32,
 }
 
 impl AddrInfoHints {
-  /// Create a new AddrInfoHints using built-in types.
-  ///
-  /// Included Enums only provide common values, for anything else
-  /// create this struct directly using appropriate values from the
-  /// libc crate.
-  #[allow(dead_code)]
-  fn new(flags: Option<i32>, address: Option<::AddrFamily>,
-         socktype: Option<::SockType>, protocol: Option<::Protocol>)
-    -> AddrInfoHints {
-    AddrInfoHints {
-      flags: flags.unwrap_or(0),
-      address: address.map_or(0, |a| a.into()),
-      socktype: socktype.map_or(0, |a| a.into()),
-      protocol: protocol.map_or(0, |a| a.into()),
+    /// Create a new AddrInfoHints using built-in types.
+    ///
+    /// Included Enums only provide common values, for anything else
+    /// create this struct directly using appropriate values from the
+    /// libc crate.
+    #[allow(dead_code)]
+    fn new(
+        flags: Option<i32>,
+        address: Option<::AddrFamily>,
+        socktype: Option<::SockType>,
+        protocol: Option<::Protocol>,
+    ) -> AddrInfoHints {
+        AddrInfoHints {
+            flags: flags.unwrap_or(0),
+            address: address.map_or(0, |a| a.into()),
+            socktype: socktype.map_or(0, |a| a.into()),
+            protocol: protocol.map_or(0, |a| a.into()),
+        }
     }
-  }
 
-  // Create libc addrinfo from AddrInfoHints struct.
-  unsafe fn as_addrinfo(&self) -> c_addrinfo {
-    let mut addrinfo: c_addrinfo = mem::zeroed();
-    addrinfo.ai_flags = self.flags;
-    addrinfo.ai_family = self.address;
-    addrinfo.ai_socktype = self.socktype;
-    addrinfo.ai_protocol = self.protocol;
-    addrinfo
-  }
+    // Create libc addrinfo from AddrInfoHints struct.
+    unsafe fn as_addrinfo(&self) -> c_addrinfo {
+        let mut addrinfo: c_addrinfo = mem::zeroed();
+        addrinfo.ai_flags = self.flags;
+        addrinfo.ai_family = self.address;
+        addrinfo.ai_socktype = self.socktype;
+        addrinfo.ai_protocol = self.protocol;
+        addrinfo
+    }
 }
 
 impl Default for AddrInfoHints {
-  /// Generate a blank AddrInfoHints struct, so new values can easily
-  /// be specified.
-  fn default() -> Self {
-    AddrInfoHints {
-      flags: 0,
-      address: 0,
-      socktype: 0,
-      protocol: 0,
+    /// Generate a blank AddrInfoHints struct, so new values can easily
+    /// be specified.
+    fn default() -> Self {
+        AddrInfoHints {
+            flags: 0,
+            address: 0,
+            socktype: 0,
+            protocol: 0,
+        }
     }
-  }
 }
 
 /// Struct that stores socket information, as returned by getaddrinfo.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AddrInfo {
-  /// Optional bitmask arguments, usually set to zero. `ai_flags` in libc.
-  pub flags: i32,
-  /// Address family for this socket (usually matches protocol family). `ai_family` in libc.
-  ///
-  /// Values are defined by the libc on your system.
-  pub address: i32,
-  /// Type of this socket. `ai_socktype` in libc.
-  ///
-  /// Values are defined by the libc on your system.
-  pub socktype: i32,
-  /// Protcol family for this socket. `ai_protocol` in libc.
-  ///
-  /// Values are defined by the libc on your system.
-  pub protocol: i32,
-  /// Socket address for this socket, usually containing an actual
-  /// IP Address and port. Combination of `ai_addrlen` and `ai_addr` in libc.
-  pub sockaddr: SocketAddr,
-  /// If requested, this is the canonical name for this socket/host. `ai_canonname` in libc.
-  pub canonname: Option<String>,
+    /// Optional bitmask arguments, usually set to zero. `ai_flags` in libc.
+    pub flags: i32,
+    /// Address family for this socket (usually matches protocol family). `ai_family` in libc.
+    ///
+    /// Values are defined by the libc on your system.
+    pub address: i32,
+    /// Type of this socket. `ai_socktype` in libc.
+    ///
+    /// Values are defined by the libc on your system.
+    pub socktype: i32,
+    /// Protcol family for this socket. `ai_protocol` in libc.
+    ///
+    /// Values are defined by the libc on your system.
+    pub protocol: i32,
+    /// Socket address for this socket, usually containing an actual
+    /// IP Address and port. Combination of `ai_addrlen` and `ai_addr` in libc.
+    pub sockaddr: SocketAddr,
+    /// If requested, this is the canonical name for this socket/host. `ai_canonname` in libc.
+    pub canonname: Option<String>,
 }
 
 impl AddrInfo {
-  /// Copy the informataion from the given addrinfo pointer, and
-  /// create a new AddrInfo struct with that information.
-  ///
-  /// Used for interfacing with getaddrinfo.
-  unsafe fn from_ptr(a: *mut c_addrinfo) -> io::Result<Self> {
-    if a.is_null() {
-      return Err(
-        io::Error::new(io::ErrorKind::Other,
-        "Supplied pointer is null."
-      ))?;
-    }
+    /// Copy the informataion from the given addrinfo pointer, and
+    /// create a new AddrInfo struct with that information.
+    ///
+    /// Used for interfacing with getaddrinfo.
+    unsafe fn from_ptr(a: *mut c_addrinfo) -> io::Result<Self> {
+        if a.is_null() {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "Supplied pointer is null.",
+            ))?;
+        }
 
-    let addrinfo = *a;
-    let ((), sockaddr) = SockAddr::init(|storage, len| {
-      *len = addrinfo.ai_addrlen as _;
-      std::ptr::copy_nonoverlapping(
-        addrinfo.ai_addr as *const u8,
-        storage as *mut u8,
-        addrinfo.ai_addrlen as usize
-      );
-      Ok(())
-    })?;
-    let sock = sockaddr.as_socket().ok_or_else(|| io::Error::new(
-      io::ErrorKind::Other,
-      format!("Found unknown address family: {}", sockaddr.family())
-    ))?;
-    Ok(AddrInfo {
-      flags: 0,
-      address: addrinfo.ai_family,
-      socktype: addrinfo.ai_socktype,
-      protocol: addrinfo.ai_protocol,
-      sockaddr: sock,
-      canonname: addrinfo.ai_canonname.as_ref().map(|s|
-        CStr::from_ptr(s).to_str().unwrap().to_owned()
-      ),
-    })
-  }
+        let addrinfo = *a;
+        let ((), sockaddr) = SockAddr::init(|storage, len| {
+            *len = addrinfo.ai_addrlen as _;
+            std::ptr::copy_nonoverlapping(
+                addrinfo.ai_addr as *const u8,
+                storage as *mut u8,
+                addrinfo.ai_addrlen as usize,
+            );
+            Ok(())
+        })?;
+        let sock = sockaddr.as_socket().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                format!("Found unknown address family: {}", sockaddr.family()),
+            )
+        })?;
+        Ok(AddrInfo {
+            flags: 0,
+            address: addrinfo.ai_family,
+            socktype: addrinfo.ai_socktype,
+            protocol: addrinfo.ai_protocol,
+            sockaddr: sock,
+            canonname: addrinfo
+                .ai_canonname
+                .as_ref()
+                .map(|s| CStr::from_ptr(*s as *mut i8).to_str().unwrap().to_owned()),
+        })
+    }
 }
 
 /// An iterator of `AddrInfo` structs, wrapping a linked-list
@@ -149,21 +165,23 @@ impl AddrInfo {
 /// It's recommended to use `.collect<io::Result<..>>()` on this
 /// to collapse possible errors.
 pub struct AddrInfoIter {
-  orig: *mut c_addrinfo,
-  cur: *mut c_addrinfo,
+    orig: *mut c_addrinfo,
+    cur: *mut c_addrinfo,
 }
 
 impl Iterator for AddrInfoIter {
-  type Item = io::Result<AddrInfo>;
+    type Item = io::Result<AddrInfo>;
 
-  fn next(&mut self) -> Option<Self::Item> {
-    unsafe {
-      if self.cur.is_null() { return None; }
-      let ret = AddrInfo::from_ptr(self.cur);
-      self.cur = (*self.cur).ai_next as *mut c_addrinfo;
-      Some(ret)
+    fn next(&mut self) -> Option<Self::Item> {
+        unsafe {
+            if self.cur.is_null() {
+                return None;
+            }
+            let ret = AddrInfo::from_ptr(self.cur);
+            self.cur = (*self.cur).ai_next as *mut c_addrinfo;
+            Some(ret)
+        }
     }
-  }
 }
 
 unsafe impl Sync for AddrInfoIter {}
@@ -185,70 +203,90 @@ impl Drop for AddrInfoIter {
 ///
 /// Resolving names from non-UTF8 locales is currently not supported (as the
 /// interface uses &str). Raise an issue if this is a concern for you.
-pub fn getaddrinfo(host: Option<&str>, service: Option<&str>, hints: Option<AddrInfoHints>)
-    -> Result<AddrInfoIter, LookupError> {
-  // We must have at least host or service.
-  if host.is_none() && service.is_none() {
-    return Err(io::Error::new(
-      io::ErrorKind::Other,
-      "Either host or service must be supplied"
-    ))?;
-  }
-
-  // Allocate CStrings, and keep around to free.
-  let host = match host {
-    Some(host_str) => Some(CString::new(host_str)?),
-    None => None
-  };
-  let c_host = host.as_ref().map_or(ptr::null(), |s| s.as_ptr());
-  let service = match service {
-    Some(service_str) => Some(CString::new(service_str)?),
-    None => None
-  };
-  let c_service = service.as_ref().map_or(ptr::null(), |s| s.as_ptr());
-
-  let c_hints = unsafe {
-    match hints {
-      Some(hints) => hints.as_addrinfo(),
-      None => mem::zeroed(),
+pub fn getaddrinfo(
+    host: Option<&str>,
+    service: Option<&str>,
+    hints: Option<AddrInfoHints>,
+) -> Result<AddrInfoIter, LookupError> {
+    // We must have at least host or service.
+    if host.is_none() && service.is_none() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            "Either host or service must be supplied",
+        ))?;
     }
-  };
 
-  let mut res = ptr::null_mut();
+    // Allocate CStrings, and keep around to free.
+    let host = match host {
+        Some(host_str) => Some(CString::new(host_str)?),
+        None => None,
+    };
+    let c_host = host.as_ref().map_or(ptr::null(), |s| s.as_ptr());
+    let service = match service {
+        Some(service_str) => Some(CString::new(service_str)?),
+        None => None,
+    };
+    let c_service = service.as_ref().map_or(ptr::null(), |s| s.as_ptr());
 
-  // Prime windows.
-  #[cfg(windows)]
-  ::win::init_winsock();
+    let c_hints = unsafe {
+        match hints {
+            Some(hints) => hints.as_addrinfo(),
+            None => mem::zeroed(),
+        }
+    };
 
-  unsafe {
-    LookupError::match_gai_error(
-      c_getaddrinfo(c_host, c_service, &c_hints, &mut res)
-    )?;
-  }
+    let mut res = ptr::null_mut();
 
-  Ok(AddrInfoIter { orig: res, cur: res })
+    // Prime windows.
+    #[cfg(windows)]
+    ::win::init_winsock();
+
+    #[cfg(windows)]
+    unsafe {
+        LookupError::match_gai_error(c_getaddrinfo(
+            c_host as *mut u8,
+            c_service as *mut u8,
+            &c_hints,
+            &mut res,
+        ))?;
+    }
+
+    #[cfg(unix)]
+    unsafe {
+        LookupError::match_gai_error(c_getaddrinfo(c_host, c_service, &c_hints, &mut res))?;
+    }
+
+    Ok(AddrInfoIter {
+        orig: res,
+        cur: res,
+    })
 }
 
 #[test]
 fn test_addrinfohints() {
-  use ::{AddrFamily, SockType};
+    use {AddrFamily, SockType};
 
-  assert_eq!(
-    AddrInfoHints {
-      flags: 1,
-      address: AddrFamily::Inet.into(),
-      socktype: SockType::Stream.into(),
-      .. AddrInfoHints::default()
-    },
-    AddrInfoHints::new(Some(1), Some(AddrFamily::Inet), Some(SockType::Stream), None)
-  );
+    assert_eq!(
+        AddrInfoHints {
+            flags: 1,
+            address: AddrFamily::Inet.into(),
+            socktype: SockType::Stream.into(),
+            ..AddrInfoHints::default()
+        },
+        AddrInfoHints::new(
+            Some(1),
+            Some(AddrFamily::Inet),
+            Some(SockType::Stream),
+            None
+        )
+    );
 
-  assert_eq!(
-    AddrInfoHints {
-      address: AddrFamily::Inet.into(),
-      socktype: SockType::Stream.into(),
-      .. AddrInfoHints::default()
-    },
-    AddrInfoHints::new(None, Some(AddrFamily::Inet), Some(SockType::Stream), None)
-  );
+    assert_eq!(
+        AddrInfoHints {
+            address: AddrFamily::Inet.into(),
+            socktype: SockType::Stream.into(),
+            ..AddrInfoHints::default()
+        },
+        AddrInfoHints::new(None, Some(AddrFamily::Inet), Some(SockType::Stream), None)
+    );
 }

--- a/src/addrinfo.rs
+++ b/src/addrinfo.rs
@@ -4,25 +4,14 @@ use std::io;
 use std::mem;
 use std::net::SocketAddr;
 use std::ptr;
-use windows_sys;
 
 #[cfg(unix)]
 use libc::{addrinfo as c_addrinfo, freeaddrinfo as c_freeaddrinfo, getaddrinfo as c_getaddrinfo};
-
-/*
-#[cfg(windows)]
-use winapi::shared::ws2def::ADDRINFOA as c_addrinfo;
-*/
 
 #[cfg(windows)]
 use windows_sys::Win32::Networking::WinSock::{
     freeaddrinfo as c_freeaddrinfo, getaddrinfo as c_getaddrinfo, ADDRINFOA as c_addrinfo,
 };
-
-/*
-#[cfg(windows)]
-use winapi::um::ws2tcpip::{freeaddrinfo as c_freeaddrinfo, getaddrinfo as c_getaddrinfo};
-*/
 
 use crate::err::LookupError;
 

--- a/src/err.rs
+++ b/src/err.rs
@@ -7,43 +7,43 @@ use std::str;
 /// or `getnameinfo`. Can automatically be coerced to an io::Error using `?`.
 #[derive(Debug)]
 pub struct LookupError {
-  kind: LookupErrorKind,
-  err_num: i32,
-  inner: io::Error,
+    kind: LookupErrorKind,
+    err_num: i32,
+    inner: io::Error,
 }
 
 impl LookupError {
-  /// Match a `gai` error, returning Ok() if it's
-  /// `0`. Otherwise return Err(LookupError) with
-  /// the specific error details.
-  pub fn match_gai_error(err: i32) -> Result<(), Self> {
-    match err {
-      0 => Ok(()),
-      _ => Err(LookupError::new(err)),
+    /// Match a `gai` error, returning Ok() if it's
+    /// `0`. Otherwise return Err(LookupError) with
+    /// the specific error details.
+    pub fn match_gai_error(err: i32) -> Result<(), Self> {
+        match err {
+            0 => Ok(()),
+            _ => Err(LookupError::new(err)),
+        }
     }
-  }
 
-  /// Create a new LookupError from a `gai` error,
-  /// returned by `getaddrinfo` and `getnameinfo`.
-  pub fn new(err: i32) -> Self {
-    LookupError {
-      kind: LookupErrorKind::new(err),
-      err_num: err,
-      inner: gai_err_to_io_err(err),
+    /// Create a new LookupError from a `gai` error,
+    /// returned by `getaddrinfo` and `getnameinfo`.
+    pub fn new(err: i32) -> Self {
+        LookupError {
+            kind: LookupErrorKind::new(err),
+            err_num: err,
+            inner: gai_err_to_io_err(err),
+        }
     }
-  }
-  /// Get the error kind explicitly. If this is an
-  /// io::Error, use From/Into to convert it.
-  pub fn kind(&self) -> LookupErrorKind {
-    self.kind
-  }
+    /// Get the error kind explicitly. If this is an
+    /// io::Error, use From/Into to convert it.
+    pub fn kind(&self) -> LookupErrorKind {
+        self.kind
+    }
 
-  /// Get the actual error number. This can be used
-  /// to find non-standard return codes from some
-  /// implementations (be careful of portability here).
-  pub fn error_num(&self) -> i32 {
-    self.err_num
-  }
+    /// Get the actual error number. This can be used
+    /// to find non-standard return codes from some
+    /// implementations (be careful of portability here).
+    pub fn error_num(&self) -> i32 {
+        self.err_num
+    }
 }
 
 /// Different kinds of lookup errors that `getaddrinfo` and
@@ -51,116 +51,118 @@ impl LookupError {
 /// between platforms, so it's recommended not to rely on them.
 #[derive(Copy, Clone, Debug)]
 pub enum LookupErrorKind {
-  /// Temporary failure in name resolution.
-  ///
-  /// May also be returend when DNS server returns a SERVFAIL.
-  Again,
-  /// Invalid value for `ai_flags' field.
-  Badflags,
-  /// NAME or SERVICE is unknown.
-  ///
-  /// May also be returned when domain doesn't exist (NXDOMAIN) or domain
-  /// exists but contains no address records (NODATA).
-  NoName,
-  /// The specified network host exists, but has no data defined.
-  ///
-  /// This is no longer a POSIX standard, however it's still returned by
-  /// some platforms. Be warned that FreeBSD does not include the corresponding
-  /// `EAI_NODATA` symbol.
-  NoData,
-  /// Non-recoverable failure in name resolution.
-  Fail,
-  /// `ai_family' not supported.
-  Family,
-  /// `ai_socktype' not supported.
-  Socktype,
-  /// SERVICE not supported for `ai_socktype'.
-  Service,
-  /// Memory allocation failure.
-  Memory,
-  /// System error returned in `errno'.
-  System,
-  /// An unknown result code was returned.
-  ///
-  /// For some platforms, you may wish to match on an unknown value directly.
-  /// Note that `gai_strerr` is used to get error messages, so the generated IO
-  /// error should contain the correct error message for the platform.
-  Unknown,
-  /// A generic C error or IO error occured.
-  ///
-  /// You should convert this `LookupError` into an IO error directly. Note
-  /// that the error code is set to 0 in the case this is returned.
-  IO,
+    /// Temporary failure in name resolution.
+    ///
+    /// May also be returend when DNS server returns a SERVFAIL.
+    Again,
+    /// Invalid value for `ai_flags' field.
+    Badflags,
+    /// NAME or SERVICE is unknown.
+    ///
+    /// May also be returned when domain doesn't exist (NXDOMAIN) or domain
+    /// exists but contains no address records (NODATA).
+    NoName,
+    /// The specified network host exists, but has no data defined.
+    ///
+    /// This is no longer a POSIX standard, however it's still returned by
+    /// some platforms. Be warned that FreeBSD does not include the corresponding
+    /// `EAI_NODATA` symbol.
+    NoData,
+    /// Non-recoverable failure in name resolution.
+    Fail,
+    /// `ai_family' not supported.
+    Family,
+    /// `ai_socktype' not supported.
+    Socktype,
+    /// SERVICE not supported for `ai_socktype'.
+    Service,
+    /// Memory allocation failure.
+    Memory,
+    /// System error returned in `errno'.
+    System,
+    /// An unknown result code was returned.
+    ///
+    /// For some platforms, you may wish to match on an unknown value directly.
+    /// Note that `gai_strerr` is used to get error messages, so the generated IO
+    /// error should contain the correct error message for the platform.
+    Unknown,
+    /// A generic C error or IO error occured.
+    ///
+    /// You should convert this `LookupError` into an IO error directly. Note
+    /// that the error code is set to 0 in the case this is returned.
+    IO,
 }
 
 impl LookupErrorKind {
-  #[cfg(all(not(windows), not(unix)))]
-  /// Create a `LookupErrorKind` from a `gai` error.
-  pub fn new(err: i32) -> Self {
-    LookupErrorKind::IO
-  }
-
-  #[cfg(unix)]
-  /// Create a `LookupErrorKind` from a `gai` error.
-  pub fn new(err: i32) -> Self {
-    use libc as c;
-    match err {
-      c::EAI_AGAIN => LookupErrorKind::Again,
-      c::EAI_BADFLAGS => LookupErrorKind::Badflags,
-      c::EAI_FAIL => LookupErrorKind::Fail,
-      c::EAI_FAMILY => LookupErrorKind::Family,
-      c::EAI_MEMORY => LookupErrorKind::Memory,
-      c::EAI_NONAME => LookupErrorKind::NoName,
-      // FreeBSD has no EAI_NODATA, so don't match it on that platform.
-      #[cfg(not(any(target_os="freebsd", target_os="emscripten")))]
-      c::EAI_NODATA => LookupErrorKind::NoData,
-      c::EAI_SERVICE => LookupErrorKind::Service,
-      c::EAI_SOCKTYPE => LookupErrorKind::Socktype,
-      c::EAI_SYSTEM => LookupErrorKind::System,
-      _ => LookupErrorKind::IO,
+    #[cfg(all(not(windows), not(unix)))]
+    /// Create a `LookupErrorKind` from a `gai` error.
+    pub fn new(err: i32) -> Self {
+        LookupErrorKind::IO
     }
-  }
 
-  #[cfg(windows)]
-  /// Create a `LookupErrorKind` from a `gai` error.
-  pub fn new(err: i32) -> Self {
-    use winapi::shared::winerror as e;
-    match err as u32 {
-      e::WSATRY_AGAIN => LookupErrorKind::Again,
-      e::WSAEINVAL => LookupErrorKind::Badflags,
-      e::WSANO_RECOVERY => LookupErrorKind::Fail,
-      e::WSAEAFNOSUPPORT => LookupErrorKind::Family,
-      e::ERROR_NOT_ENOUGH_MEMORY => LookupErrorKind::Memory,
-      e::WSAHOST_NOT_FOUND => LookupErrorKind::NoName,
-      e::WSANO_DATA => LookupErrorKind::NoData,
-      e::WSATYPE_NOT_FOUND => LookupErrorKind::Service,
-      e::WSAESOCKTNOSUPPORT => LookupErrorKind::Socktype,
-      _ => LookupErrorKind::IO,
+    #[cfg(unix)]
+    /// Create a `LookupErrorKind` from a `gai` error.
+    pub fn new(err: i32) -> Self {
+        use libc as c;
+        match err {
+            c::EAI_AGAIN => LookupErrorKind::Again,
+            c::EAI_BADFLAGS => LookupErrorKind::Badflags,
+            c::EAI_FAIL => LookupErrorKind::Fail,
+            c::EAI_FAMILY => LookupErrorKind::Family,
+            c::EAI_MEMORY => LookupErrorKind::Memory,
+            c::EAI_NONAME => LookupErrorKind::NoName,
+            // FreeBSD has no EAI_NODATA, so don't match it on that platform.
+            #[cfg(not(any(target_os = "freebsd", target_os = "emscripten")))]
+            c::EAI_NODATA => LookupErrorKind::NoData,
+            c::EAI_SERVICE => LookupErrorKind::Service,
+            c::EAI_SOCKTYPE => LookupErrorKind::Socktype,
+            c::EAI_SYSTEM => LookupErrorKind::System,
+            _ => LookupErrorKind::IO,
+        }
     }
-  }
+
+    #[cfg(windows)]
+    /// Create a `LookupErrorKind` from a `gai` error.
+    pub fn new(err: i32) -> Self {
+        // use winapi::shared::winerror as e;
+
+        use windows_sys::Win32::Networking::WinSock;
+        match err {
+            WinSock::WSATRY_AGAIN => LookupErrorKind::Again,
+            WinSock::WSAEINVAL => LookupErrorKind::Badflags,
+            WinSock::WSANO_RECOVERY => LookupErrorKind::Fail,
+            WinSock::WSAEAFNOSUPPORT => LookupErrorKind::Family,
+            WinSock::WSA_NOT_ENOUGH_MEMORY => LookupErrorKind::Memory,
+            WinSock::WSAHOST_NOT_FOUND => LookupErrorKind::NoName,
+            WinSock::WSANO_DATA => LookupErrorKind::NoData,
+            WinSock::WSATYPE_NOT_FOUND => LookupErrorKind::Service,
+            WinSock::WSAESOCKTNOSUPPORT => LookupErrorKind::Socktype,
+            _ => LookupErrorKind::IO,
+        }
+    }
 }
 
 impl From<LookupError> for io::Error {
-  fn from(err: LookupError) -> io::Error {
-    err.inner
-  }
+    fn from(err: LookupError) -> io::Error {
+        err.inner
+    }
 }
 
 impl From<io::Error> for LookupError {
-  fn from(err: io::Error) -> LookupError {
-    LookupError {
-      kind: LookupErrorKind::IO,
-      err_num: 0,
-      inner: err,
+    fn from(err: io::Error) -> LookupError {
+        LookupError {
+            kind: LookupErrorKind::IO,
+            err_num: 0,
+            inner: err,
+        }
     }
-  }
 }
 
 impl From<ffi::NulError> for LookupError {
-  fn from(err: ffi::NulError) -> LookupError {
-    let err: io::Error = err.into();
-    err.into()
-  }
+    fn from(err: ffi::NulError) -> LookupError {
+        let err: io::Error = err.into();
+        err.into()
+    }
 }
 
 #[cfg(all(not(windows), not(unix)))]
@@ -168,16 +170,10 @@ impl From<ffi::NulError> for LookupError {
 /// the appropriate error message. Note `0` is not an
 /// error, but will still map to an error
 pub(crate) fn gai_err_to_io_err(err: i32) -> io::Error {
-  match (err) {
-    0 => io::Error::new(
-      io::ErrorKind::Other,
-      "address information lookup success"
-    ),
-    _ => io::Error::new(
-      io::ErrorKind::Other,
-      "failed to lookup address information"
-    ),
-  }
+    match (err) {
+        0 => io::Error::new(io::ErrorKind::Other, "address information lookup success"),
+        _ => io::Error::new(io::ErrorKind::Other, "failed to lookup address information"),
+    }
 }
 
 #[cfg(unix)]
@@ -185,24 +181,23 @@ pub(crate) fn gai_err_to_io_err(err: i32) -> io::Error {
 /// the appropriate error message. Note `0` is not an
 /// error, but will still map to an error
 pub(crate) fn gai_err_to_io_err(err: i32) -> io::Error {
-  use libc::{EAI_SYSTEM, gai_strerror};
+    use libc::{gai_strerror, EAI_SYSTEM};
 
-  match err {
-    0 => return io::Error::new(
-      io::ErrorKind::Other,
-      "address information lookup success"
-    ),
-    EAI_SYSTEM => return io::Error::last_os_error(),
-    _ => {},
-  }
+    match err {
+        0 => return io::Error::new(io::ErrorKind::Other, "address information lookup success"),
+        EAI_SYSTEM => return io::Error::last_os_error(),
+        _ => {}
+    }
 
-  let detail = unsafe {
-    str::from_utf8(ffi::CStr::from_ptr(gai_strerror(err)).to_bytes()).unwrap()
-      .to_owned()
-  };
-  io::Error::new(io::ErrorKind::Other,
-    &format!("failed to lookup address information: {}", detail)[..]
-  )
+    let detail = unsafe {
+        str::from_utf8(ffi::CStr::from_ptr(gai_strerror(err)).to_bytes())
+            .unwrap()
+            .to_owned()
+    };
+    io::Error::new(
+        io::ErrorKind::Other,
+        &format!("failed to lookup address information: {}", detail)[..],
+    )
 }
 
 #[cfg(windows)]
@@ -210,16 +205,10 @@ pub(crate) fn gai_err_to_io_err(err: i32) -> io::Error {
 /// the appropriate error message. Note `0` is not an
 /// error, but will still map to an error
 pub(crate) fn gai_err_to_io_err(err: i32) -> io::Error {
-  use winapi::um::winsock2::WSAGetLastError;
-  match err {
-    0 => io::Error::new(
-      io::ErrorKind::Other,
-      "address information lookup success"
-    ),
-    _ => {
-      io::Error::from_raw_os_error(
-        unsafe { WSAGetLastError() }
-      )
+    // use winapi::um::winsock2::WSAGetLastError;
+    use windows_sys::Win32::Networking::WinSock::WSAGetLastError;
+    match err {
+        0 => io::Error::new(io::ErrorKind::Other, "address information lookup success"),
+        _ => io::Error::from_raw_os_error(unsafe { WSAGetLastError() }),
     }
-  }
 }

--- a/src/hostname.rs
+++ b/src/hostname.rs
@@ -21,7 +21,7 @@ use windows_sys::Win32::Networking::WinSock::gethostname as c_gethostname;
 pub fn get_hostname() -> Result<String, io::Error> {
     // Prime windows.
     #[cfg(windows)]
-    ::win::init_winsock();
+    crate::win::init_winsock();
 
     let mut c_name = [0 as c_char; 256_usize];
 

--- a/src/hostname.rs
+++ b/src/hostname.rs
@@ -2,41 +2,49 @@ use std::ffi::CStr;
 use std::io;
 use std::str;
 
-#[cfg(unix)]
-use libc::{gethostname as c_gethostname, c_char};
+/// Both libc and winapi define c_char as i8 `type c_char = i8;`
+#[allow(non_camel_case_types)]
+type c_char = i8;
 
-#[cfg(windows)]
-use winapi::ctypes::c_char;
+#[cfg(unix)]
+use libc::gethostname as c_gethostname;
+
+/*
 #[cfg(windows)]
 use winapi::um::winsock2::gethostname as c_gethostname;
+*/
+
+#[cfg(windows)]
+use windows_sys::Win32::Networking::WinSock::gethostname as c_gethostname;
 
 /// Fetch the local hostname.
 pub fn get_hostname() -> Result<String, io::Error> {
-  // Prime windows.
-  #[cfg(windows)]
-  ::win::init_winsock();
+    // Prime windows.
+    #[cfg(windows)]
+    ::win::init_winsock();
 
-  let mut c_name = [0 as c_char; 256 as usize];
-  let res = unsafe {
-    c_gethostname(c_name.as_mut_ptr(), c_name.len() as _)
-  };
+    let mut c_name = [0 as c_char; 256_usize];
 
-  // If an error occured, check errno for error message.
-  if res != 0 {
-    return Err(io::Error::last_os_error());
-  }
+    #[cfg(windows)]
+    let res = unsafe { c_gethostname(c_name.as_mut_ptr() as *mut u8, c_name.len() as _) };
 
-  let hostname = unsafe {
-    CStr::from_ptr(c_name.as_ptr())
-  };
+    #[cfg(unix)]
+    let res = unsafe { c_gethostname(c_name.as_mut_ptr(), c_name.len() as _) };
 
-  str::from_utf8(hostname.to_bytes())
-    .map(|h| h.to_owned())
-    .map_err(|_| io::Error::new(io::ErrorKind::Other, "Non-UTF8 hostname"))
+    // If an error occured, check errno for error message.
+    if res != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let hostname = unsafe { CStr::from_ptr(c_name.as_ptr()) };
+
+    str::from_utf8(hostname.to_bytes())
+        .map(|h| h.to_owned())
+        .map_err(|_| io::Error::new(io::ErrorKind::Other, "Non-UTF8 hostname"))
 }
 
 #[test]
 fn test_get_hostname() {
-  // We don't know the hostname of the local box, so just verify it doesn't return an error.
-  get_hostname().unwrap();
+    // We don't know the hostname of the local box, so just verify it doesn't return an error.
+    get_hostname().unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,17 +85,13 @@ extern crate libc;
 extern crate winapi;
 */
 
-#[cfg(windows)]
-extern crate windows_sys;
-
-extern crate socket2;
-
 mod addrinfo;
 mod err;
 mod hostname;
 mod lookup;
 mod nameinfo;
 mod types;
+
 #[cfg(windows)]
 mod win;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,27 +74,34 @@
 //!   let _ = (name, service);
 //! ```
 
-#![cfg_attr(feature="clippy", feature(plugin))]
-#![cfg_attr(feature="clippy", plugin(clippy))]
+#![cfg_attr(feature = "clippy", feature(plugin))]
+#![cfg_attr(feature = "clippy", plugin(clippy))]
 
-#[cfg(unix)] extern crate libc;
+#[cfg(unix)]
+extern crate libc;
 
-#[cfg(windows)] extern crate winapi;
+/*
+#[cfg(windows)]
+extern crate winapi;
+*/
+
+#[cfg(windows)]
+extern crate windows_sys;
 
 extern crate socket2;
 
 mod addrinfo;
-mod nameinfo;
 mod err;
-mod lookup;
-mod types;
 mod hostname;
+mod lookup;
+mod nameinfo;
+mod types;
 #[cfg(windows)]
 mod win;
 
-pub use addrinfo::{getaddrinfo, AddrInfoIter, AddrInfo, AddrInfoHints};
+pub use addrinfo::{getaddrinfo, AddrInfo, AddrInfoHints, AddrInfoIter};
+pub use err::{LookupError, LookupErrorKind};
 pub use hostname::get_hostname;
-pub use lookup::{lookup_host, lookup_addr};
+pub use lookup::{lookup_addr, lookup_host};
 pub use nameinfo::getnameinfo;
-pub use types::{SockType, Protocol, AddrFamily};
-pub use err::{LookupErrorKind, LookupError};
+pub use types::{AddrFamily, Protocol, SockType};

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -13,8 +13,8 @@ use winapi::shared::ws2def::{NI_NUMERICSERV, SOCK_STREAM};
 #[cfg(windows)]
 use windows_sys::Win32::Networking::WinSock::{NI_NUMERICSERV, SOCK_STREAM};
 
-use addrinfo::{getaddrinfo, AddrInfoHints};
-use nameinfo::getnameinfo;
+use crate::addrinfo::{getaddrinfo, AddrInfoHints};
+use crate::nameinfo::getnameinfo;
 
 /// Lookup the address for a given hostname via DNS.
 ///
@@ -86,7 +86,7 @@ fn test_rev_localhost() {
 #[test]
 fn test_hostname() {
     // Get machine's hostname.
-    let hostname = ::hostname::get_hostname().unwrap();
+    let hostname = crate::hostname::get_hostname().unwrap();
 
     // Do reverse lookup of 127.0.0.1.
     let rev_name = lookup_addr(&IpAddr::V4("127.0.0.1".parse().unwrap()));

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -5,8 +5,13 @@ use std::str;
 #[cfg(unix)]
 use libc::{NI_NUMERICSERV, SOCK_STREAM};
 
+/*
 #[cfg(windows)]
 use winapi::shared::ws2def::{NI_NUMERICSERV, SOCK_STREAM};
+*/
+
+#[cfg(windows)]
+use windows_sys::Win32::Networking::WinSock::{NI_NUMERICSERV, SOCK_STREAM};
 
 use addrinfo::{getaddrinfo, AddrInfoHints};
 use nameinfo::getnameinfo;
@@ -15,35 +20,35 @@ use nameinfo::getnameinfo;
 ///
 /// Returns an iterator of IP Addresses, or an `io::Error` on failure.
 pub fn lookup_host(host: &str) -> io::Result<Vec<IpAddr>> {
-  let hints = AddrInfoHints {
-    socktype: SOCK_STREAM,
-    ..AddrInfoHints::default()
-  };
+    let hints = AddrInfoHints {
+        socktype: SOCK_STREAM as i32,
+        ..AddrInfoHints::default()
+    };
 
-  match getaddrinfo(Some(host), None, Some(hints)) {
-    Ok(addrs) => {
-      let addrs: io::Result<Vec<_>> = addrs.map(|r| r.map(|a| a.sockaddr.ip())).collect();
-      addrs
-    },
-    Err(e) =>  {
-      reload_dns_nameserver();
-      Err(e)?
-    },
-  }
+    match getaddrinfo(Some(host), None, Some(hints)) {
+        Ok(addrs) => {
+            let addrs: io::Result<Vec<_>> = addrs.map(|r| r.map(|a| a.sockaddr.ip())).collect();
+            addrs
+        }
+        Err(e) => {
+            reload_dns_nameserver();
+            Err(e)?
+        }
+    }
 }
 
 /// Lookup the hostname of a given IP Address via DNS.
 ///
 /// Returns the hostname as a String, or an `io::Error` on failure.
 pub fn lookup_addr(addr: &IpAddr) -> io::Result<String> {
-  let sock = (*addr, 0).into();
-  match getnameinfo(&sock, NI_NUMERICSERV) {
-    Ok((name, _)) => Ok(name),
-    Err(e) =>  {
-      reload_dns_nameserver();
-      Err(e)?
-    },
-  }
+    let sock = (*addr, 0).into();
+    match getnameinfo(&sock, NI_NUMERICSERV as i32) {
+        Ok((name, _)) => Ok(name),
+        Err(e) => {
+            reload_dns_nameserver();
+            Err(e)?
+        }
+    }
 }
 
 // The lookup failure could be caused by using a stale /etc/resolv.conf.
@@ -51,40 +56,40 @@ pub fn lookup_addr(addr: &IpAddr) -> io::Result<String> {
 // We therefore force a reload of the nameserver information.
 // MacOS and IOS don't seem to have this problem.
 fn reload_dns_nameserver() {
-  cfg_if::cfg_if! {
-    if #[cfg(target_os = "macos")] {
-    } else if #[cfg(target_os = "ios")] {
-    } else if #[cfg(unix)] {
-      use libc;
-      unsafe {
-        libc::res_init();
+    cfg_if::cfg_if! {
+      if #[cfg(target_os = "macos")] {
+      } else if #[cfg(target_os = "ios")] {
+      } else if #[cfg(unix)] {
+        use libc;
+        unsafe {
+          libc::res_init();
+        }
       }
     }
-  }
 }
 
 #[test]
 fn test_localhost() {
-  let ips = lookup_host("localhost").unwrap();
-  assert!(ips.contains(&IpAddr::V4("127.0.0.1".parse().unwrap())));
-  assert!(!ips.contains(&IpAddr::V4("10.0.0.1".parse().unwrap())));
+    let ips = lookup_host("localhost").unwrap();
+    assert!(ips.contains(&IpAddr::V4("127.0.0.1".parse().unwrap())));
+    assert!(!ips.contains(&IpAddr::V4("10.0.0.1".parse().unwrap())));
 }
 
 #[cfg(unix)]
 #[test]
 fn test_rev_localhost() {
-  let name = lookup_addr(&IpAddr::V4("127.0.0.1".parse().unwrap()));
-  assert_eq!(name.unwrap(), "localhost");
+    let name = lookup_addr(&IpAddr::V4("127.0.0.1".parse().unwrap()));
+    assert_eq!(name.unwrap(), "localhost");
 }
 
 #[cfg(windows)]
 #[test]
 fn test_hostname() {
-  // Get machine's hostname.
-  let hostname = ::hostname::get_hostname().unwrap();
+    // Get machine's hostname.
+    let hostname = ::hostname::get_hostname().unwrap();
 
-  // Do reverse lookup of 127.0.0.1.
-  let rev_name = lookup_addr(&IpAddr::V4("127.0.0.1".parse().unwrap()));
+    // Do reverse lookup of 127.0.0.1.
+    let rev_name = lookup_addr(&IpAddr::V4("127.0.0.1".parse().unwrap()));
 
-  assert_eq!(rev_name.unwrap(), hostname);
+    assert_eq!(rev_name.unwrap(), hostname);
 }

--- a/src/nameinfo.rs
+++ b/src/nameinfo.rs
@@ -19,7 +19,7 @@ use winapi::um::ws2tcpip::getnameinfo as c_getnameinfo;
 #[cfg(windows)]
 use windows_sys::Win32::Networking::WinSock::getnameinfo as c_getnameinfo;
 
-use err::LookupError;
+use crate::err::LookupError;
 
 /// Retrieve the name for a given IP and Service. Acts as a thin wrapper around
 /// the libc getnameinfo.
@@ -46,7 +46,7 @@ pub fn getnameinfo(sock: &SocketAddr, flags: i32) -> Result<(String, String), Lo
 
     // Prime windows.
     #[cfg(windows)]
-    ::win::init_winsock();
+    crate::win::init_winsock();
 
     #[cfg(windows)]
     unsafe {
@@ -118,7 +118,7 @@ fn test_getnameinfo() {
 
     #[cfg(windows)]
     {
-        let hostname = ::hostname::get_hostname().unwrap();
+        let hostname = crate::hostname::get_hostname().unwrap();
         assert_eq!(name, hostname);
     }
 }

--- a/src/nameinfo.rs
+++ b/src/nameinfo.rs
@@ -11,11 +11,6 @@ use libc::getnameinfo as c_getnameinfo;
 #[allow(non_camel_case_types)]
 type c_char = i8;
 
-/*
-#[cfg(windows)]
-use winapi::um::ws2tcpip::getnameinfo as c_getnameinfo;
-*/
-
 #[cfg(windows)]
 use windows_sys::Win32::Networking::WinSock::getnameinfo as c_getnameinfo;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,140 +1,145 @@
 #[cfg(unix)]
-use libc::c_int;
-#[cfg(unix)]
 use libc as c;
 
-#[cfg(windows)]
-use winapi::ctypes::c_int;
+/// Both libc and winapi define c_int as i32 `type c_int = i32;`
+#[allow(non_camel_case_types)]
+type c_int = i32;
+
+/*
 #[cfg(windows)]
 use winapi::shared::ws2def as c;
+*/
+
+#[cfg(windows)]
+use windows_sys::Win32::Networking::WinSock as c;
 
 /// Socket Type
 ///
 /// Cross platform enum of common Socket Types. For missing types use
 /// the `libc` and `winapi` crates, depending on platform.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum SockType {
-  /// Sequenced, reliable, connection-based byte streams.
-  Stream,
-  /// Connectionless, unreliable datagrams of fixed max length.
-  DGram,
-  /// Raw protocol interface.
-  #[cfg(not(target_os = "redox"))]
-  Raw,
-  /// Reliably-delivered messages.
-  #[cfg(not(target_os = "redox"))]
-  RDM,
+    /// Sequenced, reliable, connection-based byte streams.
+    Stream,
+    /// Connectionless, unreliable datagrams of fixed max length.
+    DGram,
+    /// Raw protocol interface.
+    #[cfg(not(target_os = "redox"))]
+    Raw,
+    /// Reliably-delivered messages.
+    #[cfg(not(target_os = "redox"))]
+    RDM,
 }
 
 impl From<SockType> for c_int {
-  fn from(sock: SockType) -> c_int {
-    match sock {
-      SockType::Stream => c::SOCK_STREAM,
-      SockType::DGram => c::SOCK_DGRAM,
-      #[cfg(not(target_os = "redox"))]
-      SockType::Raw => c::SOCK_RAW,
-      #[cfg(not(target_os = "redox"))]
-      SockType::RDM => c::SOCK_RDM,
+    fn from(sock: SockType) -> c_int {
+        match sock {
+            SockType::Stream => c::SOCK_STREAM as i32,
+            SockType::DGram => c::SOCK_DGRAM as i32,
+            #[cfg(not(target_os = "redox"))]
+            SockType::Raw => c::SOCK_RAW as i32,
+            #[cfg(not(target_os = "redox"))]
+            SockType::RDM => c::SOCK_RDM as i32,
+        }
     }
-  }
 }
 
 impl PartialEq<c_int> for SockType {
-  fn eq(&self, other: &c_int) -> bool {
-    let int: c_int = (*self).into();
-    *other == int
-  }
+    fn eq(&self, other: &c_int) -> bool {
+        let int: c_int = (*self).into();
+        *other == int
+    }
 }
 
 impl PartialEq<SockType> for c_int {
-  fn eq(&self, other: &SockType) -> bool {
-    let int: c_int = (*other).into();
-    *self == int
-  }
+    fn eq(&self, other: &SockType) -> bool {
+        let int: c_int = (*other).into();
+        *self == int
+    }
 }
 
 /// Socket Protocol
 ///
 /// Cross platform enum of common Socket Protocols. For missing types use
 /// the `libc` and `winapi` crates, depending on platform.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Protocol {
-  /// Internet Control Message Protocol.
-  ICMP,
-  /// Transmission Control Protocol.
-  TCP,
-  /// User Datagram Protocol.
-  UDP,
+    /// Internet Control Message Protocol.
+    ICMP,
+    /// Transmission Control Protocol.
+    TCP,
+    /// User Datagram Protocol.
+    UDP,
 }
 
 impl From<Protocol> for c_int {
-  #[cfg(unix)]
-  fn from(sock: Protocol) -> c_int {
-    match sock {
-      Protocol::ICMP => c::IPPROTO_ICMP,
-      Protocol::TCP => c::IPPROTO_TCP,
-      Protocol::UDP => c::IPPROTO_UDP,
+    #[cfg(unix)]
+    fn from(sock: Protocol) -> c_int {
+        match sock {
+            Protocol::ICMP => c::IPPROTO_ICMP,
+            Protocol::TCP => c::IPPROTO_TCP,
+            Protocol::UDP => c::IPPROTO_UDP,
+        }
     }
-  }
 
-  #[cfg(windows)]
-  fn from(sock: Protocol) -> c_int {
-    match sock {
-      Protocol::ICMP => c::IPPROTO_ICMP as c_int,
-      Protocol::TCP => c::IPPROTO_TCP as c_int,
-      Protocol::UDP => c::IPPROTO_UDP as c_int,
+    #[cfg(windows)]
+    fn from(sock: Protocol) -> c_int {
+        match sock {
+            Protocol::ICMP => c::IPPROTO_ICMP as c_int,
+            Protocol::TCP => c::IPPROTO_TCP as c_int,
+            Protocol::UDP => c::IPPROTO_UDP as c_int,
+        }
     }
-  }
 }
 
 impl PartialEq<c_int> for Protocol {
-  fn eq(&self, other: &c_int) -> bool {
-    let int: c_int = (*self).into();
-    *other == int
-  }
+    fn eq(&self, other: &c_int) -> bool {
+        let int: c_int = (*self).into();
+        *other == int
+    }
 }
 
 impl PartialEq<Protocol> for c_int {
-  fn eq(&self, other: &Protocol) -> bool {
-    let int: c_int = (*other).into();
-    *self == int
-  }
+    fn eq(&self, other: &Protocol) -> bool {
+        let int: c_int = (*other).into();
+        *self == int
+    }
 }
 
 /// Address Family
 ///
 /// Cross platform enum of common Address Families. For missing types use
 /// the `libc` and `winapi` crates, depending on platform.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum AddrFamily {
-  /// Local to host (pipes and file-domain)
-  Unix,
-  /// IP protocol family.
-  Inet,
-  /// IP version 6.
-  Inet6
+    /// Local to host (pipes and file-domain)
+    Unix,
+    /// IP protocol family.
+    Inet,
+    /// IP version 6.
+    Inet6,
 }
 
 impl From<AddrFamily> for c_int {
-  fn from(sock: AddrFamily) -> c_int {
-    match sock {
-      AddrFamily::Unix => c::AF_UNIX,
-      AddrFamily::Inet => c::AF_INET,
-      AddrFamily::Inet6 => c::AF_INET6,
+    fn from(sock: AddrFamily) -> c_int {
+        match sock {
+            AddrFamily::Unix => c::AF_UNIX as i32,
+            AddrFamily::Inet => c::AF_INET as i32,
+            AddrFamily::Inet6 => c::AF_INET6 as i32,
+        }
     }
-  }
 }
 
 impl PartialEq<c_int> for AddrFamily {
-  fn eq(&self, other: &c_int) -> bool {
-    let int: c_int = (*self).into();
-    *other == int
-  }
+    fn eq(&self, other: &c_int) -> bool {
+        let int: c_int = (*self).into();
+        *other == int
+    }
 }
 
 impl PartialEq<AddrFamily> for c_int {
-  fn eq(&self, other: &AddrFamily) -> bool {
-    let int: c_int = (*other).into();
-    *self == int
-  }
+    fn eq(&self, other: &AddrFamily) -> bool {
+        let int: c_int = (*other).into();
+        *self == int
+    }
 }

--- a/src/win.rs
+++ b/src/win.rs
@@ -1,9 +1,9 @@
 use std::net::UdpSocket;
-use std::sync::{Once, ONCE_INIT};
+use std::sync::Once;
 
 // Start windows socket library - From socket2-rs
 pub(crate) fn init_winsock() {
-    static INIT: Once = ONCE_INIT;
+    static INIT: Once = Once::new();
 
     INIT.call_once(|| {
         // Initialize winsock through the standard library by just creating a


### PR DESCRIPTION
The pull includes `rustfmt` and `clippy` changes, migrating to `windows-sys` and unix fixes for same. The main issues were how `windows-sys` differs from `winapi` in *what type* of value it returns rather than the value itself. Eg `AF_UNIX` is of type `u16` in `windows-sys` but `i32` in `winapi`, while actually just being a constant `1` in both.

What works:

- [x] Builds (both windows and unix)
- [x] Passes tests (both windows and unix)
- [x] Sample code runs properly (both windows and unix)

What can be improved:

- [ ] It has a lot of code duplication, but it should be removed if or when # [RFC40](https://github.com/rust-lang/rust/issues/15701) stabilizes
- [ ] Using crates.io instead of git for socket2, [issue](https://github.com/rust-lang/socket2/issues/308) should be solved with this pull

@keeperofdakeys this should help with #22, I think socket2 is waiting for this and this is waiting for socket2? The only thing rust was made to prevent a deadlock xD. See if I missed anything.