### PR TITLE
Return error in lookup_addr if hostname not determined

### DIFF
--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -34,7 +34,7 @@ pub fn lookup_host(host: &str) -> io::Result<Vec<IpAddr>> {
 
 /// Lookup the hostname of a given IP Address via DNS.
 ///
-/// Returns the hostname as a String, or an `io::Error` on failure.
+/// Returns the hostname as a String, or an `io::Error` on failure or if the hostname cannot be determined.
 pub fn lookup_addr(addr: &IpAddr) -> io::Result<String> {
   let sock = (*addr, 0).into();
   match getnameinfo(&sock, NI_NUMERICSERV | NI_NAMEREQD) {
@@ -75,11 +75,6 @@ fn test_localhost() {
 fn test_rev_localhost() {
   let name = lookup_addr(&IpAddr::V4("127.0.0.1".parse().unwrap()));
   assert_eq!(name.unwrap(), "localhost");
-}
-
-#[test]
-fn test_rev_localhost_err() {
-  assert!(lookup_addr(&IpAddr::V4("0.0.0.0".parse().unwrap())).is_err());
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
Hey :)

The documentation for `lookup_addr` states
> Returns the hostname as a String, or an `io::Error` on failure.

This leads to an expectation that an error will be returned if the hostname cannot be determined (for example, due to `NXDOMAIN`). This isn't currently the case as, in this scenario, `lookup_addr()` just returns the IP address. This expectation originated the issue described in https://github.com/bottlerocket-os/bottlerocket/issues/3013, where the `netdog` tool relies on an eventual error reported by `dns-lookup` to go on and try different methods to determine an instance's hostname.

So in this PR I propose setting the `NI_NAMEREQD` flag in the call to `getnameinfo()`:
> If set, then an error is returned if the hostname cannot be determined.

Please let me know what you think of this change, or if I can improve this PR in any way. Thank you in advance!