### PR TITLE
Add apple tvos support

### DIFF
--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -54,6 +54,7 @@ fn reload_dns_nameserver() {
     cfg_if::cfg_if! {
       if #[cfg(target_os = "macos")] {
       } else if #[cfg(target_os = "ios")] {
+      } else if #[cfg(target_os = "tvos")] {
       } else if #[cfg(unix)] {
         use libc;
         unsafe {


### PR DESCRIPTION
This PR allows using dns-lookup lib to target [tier 3 *-apple builds](https://doc.rust-lang.org/nightly/rustc/platform-support/apple-tvos.html):

- Apple tvOS on aarch64
- Apple tvOS Simulator on x86_64