### PR TITLE
make lookup_host() return an iterator as described in the doc

### DIFF
--- a/src/addrinfo.rs
+++ b/src/addrinfo.rs
@@ -215,7 +215,7 @@ pub fn getaddrinfo(
 ) -> Result<AddrInfoIter, LookupError> {
     // We must have at least host or service.
     if host.is_none() && service.is_none() {
-        return Err(io::Error::new(
+        Err(io::Error::new(
             io::ErrorKind::Other,
             "Either host or service must be supplied",
         ))?;

--- a/src/addrinfo.rs
+++ b/src/addrinfo.rs
@@ -130,6 +130,7 @@ impl AddrInfo {
         let addrinfo = *a;
         let ((), sockaddr) = SockAddr::try_init(|storage, len| {
             *len = addrinfo.ai_addrlen as _;
+            #[cfg_attr(windows, allow(clippy::unnecessary_cast))]
             std::ptr::copy_nonoverlapping(
                 addrinfo.ai_addr as *const u8,
                 storage as *mut u8,
@@ -178,7 +179,10 @@ impl Iterator for AddrInfoIter {
                 return None;
             }
             let ret = AddrInfo::from_ptr(self.cur);
-            self.cur = (*self.cur).ai_next as *mut c_addrinfo;
+            #[cfg_attr(windows, allow(clippy::unnecessary_cast))]
+            {
+                self.cur = (*self.cur).ai_next as *mut c_addrinfo;
+            }
             Some(ret)
         }
     }

--- a/src/nameinfo.rs
+++ b/src/nameinfo.rs
@@ -35,9 +35,9 @@ pub fn getnameinfo(sock: &SocketAddr, flags: i32) -> Result<(String, String), Lo
     // Hard code maximums, as they aren't defined in libc/windows-sys.
 
     // Allocate buffers for name and service strings.
-    let mut c_host = [0 as u8; 1024_usize];
+    let mut c_host = [0_u8; 1024];
     // No NI_MAXSERV, so use suggested value.
-    let mut c_service = [0 as u8; 32_usize];
+    let mut c_service = [0_u8; 32];
 
     // Prime windows.
     #[cfg(windows)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -28,6 +28,7 @@ pub enum SockType {
 
 impl From<SockType> for c_int {
     fn from(sock: SockType) -> c_int {
+        #[cfg_attr(windows, allow(clippy::useless_conversion))]
         (match sock {
             SockType::Stream => c::SOCK_STREAM,
             SockType::DGram => c::SOCK_DGRAM,
@@ -70,6 +71,7 @@ pub enum Protocol {
 
 impl From<Protocol> for c_int {
     fn from(sock: Protocol) -> c_int {
+        #[cfg_attr(windows, allow(clippy::useless_conversion))]
         (match sock {
             Protocol::ICMP => c::IPPROTO_ICMP,
             Protocol::TCP => c::IPPROTO_TCP,


### PR DESCRIPTION
Makes the `lookup_host()` function return a `Iterator` as stated in the docs instead of a `Vec<_>`.