### PR TITLE
deps(socket2): update to 0.6 with windows-sys 0.60

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,13 @@ include = [
 ]
 
 [dependencies]
-socket2 = "^0.5.8"
+socket2 = "^0.6.0"
 cfg-if = "^1.0"
 
 # Note that version of windows-sys is pinned to version used in socket2 release
 # due to use of shared variables like SOCKADDR.
 [target."cfg(windows)".dependencies.windows-sys]
-version = "^0.52"
+version = "^0.60"
 features = ["Win32_Networking_WinSock", "Win32_Foundation"]
 
 [target."cfg(unix)".dependencies]


### PR DESCRIPTION
Fortunately no breaking changes for the project, libs are starting to migrate to it (socket2 0.6) so I'd say to update it, also updated windows-sys to 0.60 to match socket2.
I'd be grateful if a release can be done after the merge of this PR.