### PR TITLE
cargo: specify rust-version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "dns-lookup"
 version = "3.0.1"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 authors = ["Josh Driver <keeperofdakeys@gmail.com>"]
 description = "A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants."
 documentation = "https://docs.rs/dns-lookup"
@@ -15,6 +16,15 @@ include = [
     "LICENSE*",
     "Cargo.*"
 ]
+
+[workspace]
+members = [
+    "utils",
+]
+
+[workspace.package]
+edition = "2021"
+rust-version = "1.82"
 
 [dependencies]
 socket2 = "^0.6.0"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "dns-utils"
+edition.workspace = true
+rust-version.workspace = true
 version = "0.1.0"
 authors = ["Josh <keeperofdakeys@gmail.com>"]
 

--- a/utils/src/test.rs
+++ b/utils/src/test.rs
@@ -2,23 +2,21 @@ extern crate libc;
 extern crate dns_lookup as dns;
 
 use std::io;
-use dns::LookupErrorKind;
+use crate::dns::LookupErrorKind;
 
 fn main() {
-  let mut hints = dns::AddrInfoHints::default();
-  hints.flags = 0x0040;
-  // hints.socktype = dns::SockType::Stream;
-  // hints.address = dns::AddrFamily::Inet;
-  // hints.protocol = dns::ProtoFamily::Inet;
+  let hints = dns::AddrInfoHints {
+    flags: 0x0040,
+    ..Default::default()
+  };
   unsafe {
     let cstr = std::ffi::CString::new("").unwrap();
-    libc::setlocale(libc::LC_ALL, cstr.as_ptr() as *const _ as *const i8);
+    libc::setlocale(libc::LC_ALL, cstr.as_ptr() as *const _);
   }
   let list: io::Result<Vec<_>> =
     dns::getaddrinfo(Some("☃.net"), Some("http"), Some(hints)).unwrap().collect();
   println!("{:?}", list);
-  let foo = dns::getaddrinfo(Some("☃.net"), Some("foobar"), Some(hints));
-  match foo {
+  match dns::getaddrinfo(Some("☃.net"), Some("foobar"), Some(hints)) {
     Ok(_) => {},
     Err(e) => match e.kind() {
       LookupErrorKind::NoName => println!("NoName"),


### PR DESCRIPTION
- specify Rust 1.82 as this is the actual MSRV
- define a workspace
- fix utils clippy lints