### PR TITLE
cargo: remove deprecated package authors field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "dns-lookup"
 version = "3.0.1"
 edition.workspace = true
 rust-version.workspace = true
-authors = ["Josh Driver <keeperofdakeys@gmail.com>"]
 description = "A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants."
 documentation = "https://docs.rs/dns-lookup"
 repository = "https://github.com/keeperofdakeys/dns-lookup/"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -3,7 +3,6 @@ name = "dns-utils"
 edition.workspace = true
 rust-version.workspace = true
 version = "0.1.0"
-authors = ["Josh <keeperofdakeys@gmail.com>"]
 
 [dependencies]
 argparse = "0.2"


### PR DESCRIPTION
`package.authors` is deprecated: https://github.com/rust-lang/cargo/pull/15068