### PR TITLE
Lower MSRV to 1.63

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,5 +45,4 @@ jobs:
     - name: Run tests
       run: cargo minimal-versions test --rust-version --verbose
 
-
     timeout-minutes: 10

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "dns-lookup"
 version = "4.0.1"
-edition.workspace = true
-rust-version.workspace = true
+edition = "2021"
+rust-version = "1.63"
 description = "A simple dns resolving api, much like rust's unstable api. Also includes getaddrinfo and getnameinfo wrappers for libc variants."
 documentation = "https://docs.rs/dns-lookup"
 repository = "https://github.com/keeperofdakeys/dns-lookup/"
@@ -21,12 +21,8 @@ members = [
     "utils",
 ]
 
-[workspace.package]
-edition = "2021"
-rust-version = "1.71"
-
 [dependencies]
-socket2 = "^0.6.0"
+socket2 = ">=0.5.10, <0.7.0"
 cfg-if = "^1.0"
 
 # Note that version of windows-sys is pinned to version used in socket2 release

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dns-utils"
-edition.workspace = true
-rust-version.workspace = true
+edition = "2021"
+rust-version = "1.63"
 version = "0.1.0"
 
 [dependencies]


### PR DESCRIPTION
- Lower the crate's MSRV from Rust 1.71 to 1.63.
- Relax the `socket2` dependency from `^0.6.0` to `>=0.5.10, <0.7.0`, allowing older compatible versions to be selected for older Rust toolchains.
- Remove workspace inheritance from, since Rust 1.63 does not support the required workspace package inheritance.
