### PR TITLE
Fix stale Crates.io version badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # dns-lookup
-[![Crates.io](https://img.shields.io/crates/v/dns-lookup.svg?maxAge=2592000)](https://crates.io/crates/dns-lookup)
+
+[![Crates.io](https://img.shields.io/crates/v/dns-lookup.svg)](https://crates.io/crates/dns-lookup)
 
 A small wrapper for libc to perform simple DNS lookups.
 


### PR DESCRIPTION
Update the Crates.io shield URL in the README to remove the 30-day cache duration.
