### PR TITLE
Fix build failure on wasi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
     "utils",
 ]
 
-[dependencies]
+[target."cfg(any(unix, windows))".dependencies]
 socket2 = ">=0.5.10, <0.7.0"
 cfg-if = "^1.0"
 
@@ -33,3 +33,6 @@ features = ["Win32_Networking_WinSock", "Win32_Foundation"]
 
 [target."cfg(unix)".dependencies]
 libc = "^0.2"
+
+[features]
+default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,8 @@
 //!   let _ = (name, service);
 //! ```
 
+#![cfg(any(unix, windows))]
+
 mod addrinfo;
 mod err;
 mod hostname;

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 rust-version = "1.63"
 version = "0.1.0"
 
-[dependencies]
+[target."cfg(any(unix, windows))".dependencies]
 argparse = "0.2.1"
 libc = "^0.2"
 dns-lookup = { path = ".." }
@@ -12,3 +12,4 @@ dns-lookup = { path = ".." }
 [[bin]]
 path="src/test.rs"
 name="test"
+required-features = ["dns-lookup/default"]

--- a/utils/src/test.rs
+++ b/utils/src/test.rs
@@ -1,3 +1,5 @@
+#![cfg(any(unix, windows))]
+
 extern crate libc;
 extern crate dns_lookup as dns;
 


### PR DESCRIPTION
The crate currently fails to build for `wasi` because `socket2` does not support this target.

This change disables all functionality on non-Unix/Windows targets, allowing the crate to compile successfully as a stub on those platforms.